### PR TITLE
[WIP] 教員名でシラバスを検索するAPIの実装

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -99,7 +99,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/syllabus/teacher/{name}": {
+        "/syllabus/teacher": {
             "get": {
                 "description": "パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．",
                 "consumes": [
@@ -117,7 +117,7 @@ const docTemplate = `{
                         "type": "string",
                         "description": "teacher name",
                         "name": "name",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     }
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -98,6 +98,38 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/syllabus/teacher/{name}": {
+            "get": {
+                "description": "パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "教員名でシラバスを検索します．",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "teacher name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SyllabusViewModel"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -87,6 +87,38 @@
                     }
                 }
             }
+        },
+        "/syllabus/teacher/{name}": {
+            "get": {
+                "description": "パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "教員名でシラバスを検索します．",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "teacher name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SyllabusViewModel"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -88,7 +88,7 @@
                 }
             }
         },
-        "/syllabus/teacher/{name}": {
+        "/syllabus/teacher": {
             "get": {
                 "description": "パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．",
                 "consumes": [
@@ -106,7 +106,7 @@
                         "type": "string",
                         "description": "teacher name",
                         "name": "name",
-                        "in": "path",
+                        "in": "query",
                         "required": true
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,4 +82,25 @@ paths:
       summary: シラバスデータをランダム取得
       tags:
       - tags
+  /syllabus/teacher/{name}:
+    get:
+      consumes:
+      - application/json
+      description: パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．
+      parameters:
+      - description: teacher name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.SyllabusViewModel'
+      summary: 教員名でシラバスを検索します．
+      tags:
+      - tags
 swagger: "2.0"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,14 +82,14 @@ paths:
       summary: シラバスデータをランダム取得
       tags:
       - tags
-  /syllabus/teacher/{name}:
+  /syllabus/teacher:
     get:
       consumes:
       - application/json
       description: パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．
       parameters:
       - description: teacher name
-        in: path
+        in: query
         name: name
         required: true
         type: string

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
     routes.SyllabusRoutes(router, db)
 	routes.SyllabusRandomRoutes(router, db)
 	routes.SyllabusFacultyRoutes(router, db)
+	routes.SyllabusTeacherRoutes(router, db)
 	// ....
 	// ....
 

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -22,7 +22,7 @@ func (sc *SyllabusController) GetSyllabusByTeacher(c *gin.Context) {
 	// `都立太郎` -> `%都%立%太%郎%`
 	queryTeacherName := "%"
 	for _, r := range teacherName {
-		if !IsWhiteSpace(r) {
+		if !isWhiteSpace(r) {
 			queryTeacherName += fmt.Sprintf("%s%%", string(r))
 		}
 	}

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -18,7 +18,7 @@ func IsWhiteSpace(r rune) bool {
 // documentation: 
 func (sc *SyllabusController) GetSyllabusByTeacher(c *gin.Context) {
 	var syllabus []models.SyllabusBaseInfo
-	teacherName := c.Param("name")
+	teacherName := c.DefaultQuery("name", "")
 	// `都立太郎` -> `%都%立%太%郎%`
 	queryTeacherName := "%"
 	for _, r := range teacherName {

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"InfoLinkAPI/src/models"
 	"net/http"
+	"unicode"
 
 	"github.com/gin-gonic/gin"
 )

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
-
+// rune が空白文字であれば true を返却
+func IsWhiteSpace(r rune) bool {
+	return unicode.IsSpace(r)
+}
 // GetSyllabusByFaculty 指定した教員名が部分一致するシラバスを返す。
 //
 // 引数: 教員名 e.g. 山口

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"InfoLinkAPI/src/models"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetSyllabusByFaculty 指定した教員名が部分一致するシラバスを返す。
+//
+// 引数: 教員名 e.g. 山口
+// 戻り値: teacherフィールドが引数に部分一致したシラバス
+// documentation: 
+func (sc *SyllabusController) GetSyllabusByTeacher(c *gin.Context) {
+	var syllabus []models.SyllabusBaseInfo
+	teacherName := c.Param("name")
+	teacherName = "%" + teacherName + "%" //部分一致
+	result := sc.DB.Where("teacher LIKE ?", teacherName).Find(&syllabus)
+
+	if result.Error != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
+		return
+	}
+	
+	c.JSON(http.StatusOK, syllabus)
+}

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -4,7 +4,7 @@ import (
 	"InfoLinkAPI/src/models"
 	"net/http"
 	"unicode"
-
+	"fmt"
 	"github.com/gin-gonic/gin"
 )
 // rune が空白文字であれば true を返却
@@ -21,12 +21,12 @@ func (sc *SyllabusController) GetSyllabusByTeacher(c *gin.Context) {
 	teacherName := c.Param("name")
 	// `都立太郎` -> `%都%立%太%郎%`
 	queryTeacherName := "%"
-	for _, rune := range teacherName {
-		if !IsWhiteSpace(rune) {
-			queryTeacherName += fmt.Sprintf("%s%%", rune)
+	for _, r := range teacherName {
+		if !IsWhiteSpace(r) {
+			queryTeacherName += fmt.Sprintf("%s%%", string(r))
 		}
 	}
-	result := sc.DB.Where("teacher LIKE ?", teacherName).Find(&syllabus)
+	result := sc.DB.Where("teacher LIKE ?", queryTeacherName).Find(&syllabus)
 
 	if result.Error != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 // rune が空白文字であれば true を返却
-func IsWhiteSpace(r rune) bool {
+func isWhiteSpace(r rune) bool {
 	return unicode.IsSpace(r)
 }
 // GetSyllabusByFaculty 指定した教員名が部分一致するシラバスを返す。

--- a/src/controllers/syllabus_teacher.go
+++ b/src/controllers/syllabus_teacher.go
@@ -19,7 +19,13 @@ func IsWhiteSpace(r rune) bool {
 func (sc *SyllabusController) GetSyllabusByTeacher(c *gin.Context) {
 	var syllabus []models.SyllabusBaseInfo
 	teacherName := c.Param("name")
-	teacherName = "%" + teacherName + "%" //部分一致
+	// `都立太郎` -> `%都%立%太%郎%`
+	queryTeacherName := "%"
+	for _, rune := range teacherName {
+		if !IsWhiteSpace(rune) {
+			queryTeacherName += fmt.Sprintf("%s%%", rune)
+		}
+	}
 	result := sc.DB.Where("teacher LIKE ?", teacherName).Find(&syllabus)
 
 	if result.Error != nil {

--- a/src/routes/syllabus_teacher.go
+++ b/src/routes/syllabus_teacher.go
@@ -13,10 +13,10 @@ import (
 // @Tags tags
 // @Accept  json
 // @Produce  json
-// @Param	name	path	string	true	"teacher name"
+// @Param	name	query	string	true	"teacher name"
 // @Success 200 {object} models.SyllabusViewModel
-// @Router /syllabus/teacher/{name} [get]
+// @Router /syllabus/teacher [get]
 func SyllabusTeacherRoutes(router *gin.Engine, db *gorm.DB){
 	syllabusController := controllers.SyllabusController{DB: db}
-	router.GET("/syllabus/teacher/:name", syllabusController.GetSyllabusByTeacher)
+	router.GET("/syllabus/teacher", syllabusController.GetSyllabusByTeacher)
 }

--- a/src/routes/syllabus_teacher.go
+++ b/src/routes/syllabus_teacher.go
@@ -1,0 +1,22 @@
+package routes
+
+import (
+	"InfoLinkAPI/src/controllers"
+	_ "InfoLinkAPI/src/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// @Summary 教員名でシラバスを検索します．
+// @Description パラメータに与えた教員名を，syllabus_base_infos.teacherとの部分一致で検索します．
+// @Tags tags
+// @Accept  json
+// @Produce  json
+// @Param	name	path	string	true	"teacher name"
+// @Success 200 {object} models.SyllabusViewModel
+// @Router /syllabus/teacher/{name} [get]
+func SyllabusTeacherRoutes(router *gin.Engine, db *gorm.DB){
+	syllabusController := controllers.SyllabusController{DB: db}
+	router.GET("/syllabus/teacher/:name", syllabusController.GetSyllabusByTeacher)
+}

--- a/src/routes/syllabus_teacher_test.go
+++ b/src/routes/syllabus_teacher_test.go
@@ -1,0 +1,891 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+	"database/sql"
+)
+
+// ------------------------------
+// テスト方針
+// ------------------------------
+// 以下を検証したい．
+// 1. 指定した名前の教員が担当する授業が返されていること
+// 2. 指定した名前の教員以外が担当する授業が返されていないこと
+// 3. 姓名の間のスペースの有無を吸収できているか
+// 4. アルファベットの全角半角に対応できているか
+// 
+// for1,2: test1~3
+// for2: test4
+// for3: test5
+// for4: test6
+// 
+// test1: 異なる2日本人教員について正常な絞り込みかどうか検証
+// test2: 似た名前の2日本人教員について正常な絞り込みかどうか検証
+// test3: 異なる2外国人教員について正常な絞り込みかどうか検証
+// test4: 存在しない教員について結果が空になるか検証
+// test5: 姓名間のスペースの違いを吸収できているか検証（日本人教員）
+// test6: 全角半角の違いに対応できているか検証（外国人教員）
+
+// union
+func TestSyllabusTeacherRoutes(t *testing.T) {
+	type TestCase struct {
+		name string
+		testFunc func(t *testing.T)
+	}
+
+	tests := []TestCase{
+		{
+			name: "異なる名前の日本人教員2人",
+			testFunc: TestSyllabusTeacherRouteJpName,
+		},
+		{
+			name: "似た名前の日本人教員2人",
+			testFunc: TestSyllabusTeacherRouteJpNameClose,
+		},
+		{
+			name: "異なる名前の外国人教員2人",
+			testFunc: TestSyllabusTeacherRouteEnName,
+		},
+		{
+			name: "存在しない教員",
+			testFunc: TestSyllabusTeacherRouteUnknownName,
+		},
+		// {
+		// 	name: "姓名間のスペースの有無への頑健性（日本人教員）",
+		// 	testFunc: ,
+		// },
+		// {
+		// 	name: "姓名間のスペースの有無への頑健性（外国人教員）",
+		// 	testFunc: ,
+		// },
+	}
+
+	for _, tt := range tests{
+		t.Run(tt.name, func(t *testing.T){
+			tt.testFunc(t)
+		})
+	}
+}
+
+// setup func
+func TeacherRouteTestSetup(t *testing.T) (*sql.DB, *gorm.DB, sqlmock.Sqlmock, []string) {
+	// mockDBの開設
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+	}
+	// DBのカラム名を定義しておく
+	cols := []string{"year", "season", "day", "period", "teacher", "name", "lecture_id", "credits", "url", "type", "faculty"}
+	// GORMからmockDBに接続する
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{
+		Conn: db,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a GORM database connection", err)
+	}
+	// Ginエンジンをtest用に設定
+	gin.SetMode(gin.TestMode)
+	return db, gormDB, mock, cols
+}
+
+// test1
+func TestSyllabusTeacherRouteJpName(t *testing.T) {
+	// 異なる名前の日本人教員について正常に絞り込みが行われているか検証
+	// 2ケースについて検証することで，指定していない教員のシラバスが検索結果に含まれていないことを検証できる
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+
+	// ------------------------------
+	// case1: name=岡本 正吾
+	// ------------------------------
+	// mockの設定
+	expectedRows1 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"後期", 
+		"金", 
+		"3限", 
+		"岡本 正吾", 
+		"バーチャルリアリティ", 
+		"L0148", 
+		2, 
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/5/2023_A6_L0148.html", 
+		"専門教育科目", 
+		"A6", 
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%岡%本%正%吾%").WillReturnRows(expectedRows1)
+
+	// 検証用のcontext
+	writer1 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context1, engine1 := gin.CreateTestContext(writer1)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine1, gormDB)
+
+	// リクエストのシミュレート
+	context1.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=岡本 正吾", nil)
+	engine1.ServeHTTP(writer1, context1.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer1.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[{
+    "Year": 2023,
+    "Season": "後期",
+    "Day": "金",
+    "Period": "3限",
+    "Teacher": "岡本 正吾",
+    "Name": "バーチャルリアリティ",
+    "LectureId": "L0148",
+    "Credits": 2,
+    "URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/5/2023_A6_L0148.html",
+    "Type": "専門教育科目",
+    "Faculty": "A6",
+    "DeletedAt": null
+    }]`,
+	writer1.Body.String())
+
+	// ------------------------------
+	// case2: name=小町 守
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"集中",
+		"他",
+		"0限",
+		"小町 守",
+		"自然言語処理",
+		"L0161",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0161.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%小%町%守%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontextを設ける
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=小町 守", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[{
+    "Year": 2023,
+    "Season": "集中",
+    "Day": "他",
+    "Period": "0限",
+    "Teacher": "小町 守",
+    "Name": "自然言語処理",
+    "LectureId": "L0161",
+    "Credits": 2,
+    "URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0161.html",
+    "Type": "専門教育科目",
+    "Faculty": "A6",
+    "DeletedAt": null
+    }]`,
+	writer2.Body.String())
+}
+
+// test2
+func TestSyllabusTeacherRouteJpNameClose(t *testing.T) {
+	// 似た名前（同じ苗字）の日本人教員について正常に絞り込みが行われているか検証
+	// case1(姓のみ)で異なる名前の教員のシラバスが戻ってくることを検証
+	// case2(姓名)でもう一方の教員のシラバスが除外されたことを検証
+	// case3 is mirror of case2.
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+
+	// ------------------------------
+	// case1: name=山口
+	// ------------------------------
+	// mockの設定
+	expectedRows1 := sqlmock.NewRows(cols)
+	expectedRows1.AddRow(
+		2023,
+		"集中",
+		"他",
+		"0限",
+		"山口 大輔",
+		"情報と職業",
+		"L0001",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0001.html",
+		"専門教育科目",
+		"A6",
+	)
+	expectedRows1.AddRow(
+		2023,
+		"後期",
+		"火",
+		"1限",
+		"山口 京一郎",
+		"実践英語IIb(612)",
+		"A0555",
+		1,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/2/2023_0D02_A0555.html",
+		"言語科目",
+		"0D02",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%山%口%").WillReturnRows(expectedRows1)
+
+	// 検証用のcontext
+	writer1 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context1, engine1 := gin.CreateTestContext(writer1)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine1, gormDB)
+
+	// リクエストのシミュレート
+	context1.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=山口", nil)
+	engine1.ServeHTTP(writer1, context1.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer1.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "集中",
+			"Day": "他",
+			"Period": "0限",
+			"Teacher": "山口 大輔",
+			"Name": "情報と職業",
+			"LectureId": "L0001",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0001.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+	  	},
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "火",
+			"Period": "1限",
+			"Teacher": "山口 京一郎",
+			"Name": "実践英語IIb(612)",
+			"LectureId": "A0555",
+			"Credits": 1,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/2/2023_0D02_A0555.html",
+			"Type": "言語科目",
+			"Faculty": "0D02",
+			"DeletedAt": null
+		}
+	]`,
+	writer1.Body.String())
+
+	// ------------------------------
+	// case2: name=山口 大輔
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"集中",
+		"他",
+		"0限",
+		"山口 大輔",
+		"情報と職業",
+		"L0001",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0001.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%山%口%大%輔%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontextを設ける
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=山口 大輔", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "集中",
+			"Day": "他",
+			"Period": "0限",
+			"Teacher": "山口 大輔",
+			"Name": "情報と職業",
+			"LectureId": "L0001",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/9/2023_A6_L0001.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+	  	}
+	]`,
+	writer2.Body.String())
+
+	// ------------------------------
+	// case3: name=山口 京一郎
+	// ------------------------------
+	// mockの設定
+	expectedRows3 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"後期",
+		"火",
+		"1限",
+		"山口 京一郎",
+		"実践英語IIb(612)",
+		"A0555",
+		1,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/2/2023_0D02_A0555.html",
+		"言語科目",
+		"0D02",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%山%口%京%一%郎%").WillReturnRows(expectedRows3)
+
+	// 検証用のcontextを設ける
+	writer3 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context3, engine3 := gin.CreateTestContext(writer3)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine3, gormDB)
+
+	// リクエストのシミュレート
+	context3.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=山口 京一郎", nil)
+	engine2.ServeHTTP(writer3, context3.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer3.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "火",
+			"Period": "1限",
+			"Teacher": "山口 京一郎",
+			"Name": "実践英語IIb(612)",
+			"LectureId": "A0555",
+			"Credits": 1,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/2/2023_0D02_A0555.html",
+			"Type": "言語科目",
+			"Faculty": "0D02",
+			"DeletedAt": null
+	  	}
+	]`,
+	writer3.Body.String())
+}
+
+// test3
+func TestSyllabusTeacherRouteEnName(t *testing.T) {
+	// 異なる名前の外国人教員について正常に絞り込みが行われているか検証
+	// 2ケースについて検証することで，指定していない教員のシラバスが検索結果に含まれていないことを検証できる
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+
+	// ------------------------------
+	// case1: name=Thomas Brotherhood
+	// ------------------------------
+	// mockの設定
+	expectedRows1 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"後期",
+		"月",
+		"3限",
+		"ThomasBrotherhood",
+		"MigrationandJapan",
+		"X0185",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_0D05_X0185.html",
+		"教養/都市・社会・環境",
+		"0D05",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%T%h%o%m%a%s%B%r%o%t%h%e%r%h%o%o%d%").WillReturnRows(expectedRows1)
+
+	// 検証用のcontext
+	writer1 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context1, engine1 := gin.CreateTestContext(writer1)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine1, gormDB)
+
+	// リクエストのシミュレート
+	context1.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=Thomas Brotherhood", nil)
+	engine1.ServeHTTP(writer1, context1.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer1.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "月",
+			"Period": "3限",
+			"Teacher": "ThomasBrotherhood",
+			"Name": "MigrationandJapan",
+			"LectureId": "X0185",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_0D05_X0185.html",
+			"Type": "教養/都市・社会・環境",
+			"Faculty": "0D05",
+			"DeletedAt": null
+    	}
+	]`,
+	writer1.Body.String())
+
+	// ------------------------------
+	// case2: name=James Baldwin
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"前期",
+		"木",
+		"6限",
+		"JamesBaldwin",
+		"医科学英語プレゼンテーションスキルⅠ",
+		"U0525",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/1/4/2023_16_U0525.html",
+		"専攻科目",
+		"16",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%J%a%m%e%s%B%a%l%d%w%i%n%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontextを設ける
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=James Baldwin", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[{
+		"Year": 2023,
+		"Season": "前期",
+		"Day": "木",
+		"Period": "6限",
+		"Teacher": "JamesBaldwin",
+		"Name": "医科学英語プレゼンテーションスキルⅠ",
+		"LectureId": "U0525",
+		"Credits": 2,
+		"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/1/4/2023_16_U0525.html",
+		"Type": "専攻科目",
+		"Faculty": "16",
+		"DeletedAt": null
+    }]`,
+	writer2.Body.String())
+}
+
+// test4
+func TestSyllabusTeacherRouteUnknownName(t *testing.T) {
+	// 存在しない教員名を指定したときに空が返されることを検証
+	// 複数のケースについて検証
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+
+	// ------------------------------
+	// case1: name=戌亥 とこ
+	// ------------------------------
+	// mockの設定
+	expectedRows1 := sqlmock.NewRows(cols)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%戌%亥%と%こ%").WillReturnRows(expectedRows1)
+
+	// 検証用のcontext
+	writer1 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context1, engine1 := gin.CreateTestContext(writer1)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine1, gormDB)
+
+	// リクエストのシミュレート
+	context1.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=戌亥 とこ", nil)
+	engine1.ServeHTTP(writer1, context1.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer1.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[]`,
+	writer1.Body.String())
+
+	// ------------------------------
+	// case2: name=高橋 恵
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%高%橋%恵%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontextを設ける
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=高橋 恵", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[]`,
+	writer2.Body.String())
+}
+
+// test5
+func TestSyllabusTeacherRouteWhitespaceVariation(t *testing.T) {
+	// 姓名の区切り文字の種類に関する頑健性を検証
+	// 区切りなし，半角スペース，全角スペースの3通り．
+	// 発行されるSQLクエリの時点で違いを吸収していることを想定する．
+	// case1: 区切り無し
+	// case2: 半角区切り
+	// case3: 全角区切り
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+	
+	// ------------------------------
+	// case1: name=塩田さやか
+	// ------------------------------
+	// mockの設定
+	expectedRows1 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"前期",
+		"水",
+		"4限",
+		"塩田 さやか",
+		"画像処理（CS）",
+		"L0133",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0133.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%塩%田%さ%や%か%").WillReturnRows(expectedRows1)
+
+	// 検証用のcontext
+	writer1 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context1, engine1 := gin.CreateTestContext(writer1)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine1, gormDB)
+
+	// リクエストのシミュレート
+	context1.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=塩田さやか", nil)
+	engine1.ServeHTTP(writer1, context1.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer1.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "前期",
+			"Day": "水",
+			"Period": "4限",
+			"Teacher": "塩田 さやか",
+			"Name": "画像処理（CS）",
+			"LectureId": "L0133",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0133.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+		}
+	]`,
+	writer1.Body.String())
+
+	// ------------------------------
+	// case2: name=小野 順貴
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"後期",
+		"水",
+		"4限",
+		"小野 順貴",
+		"音響・音声信号処理",
+		"L0146",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0146.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%小%野%順%貴%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontext
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=小野 順貴", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "水",
+			"Period": "4限",
+			"Teacher": "小野 順貴",
+			"Name": "音響・音声信号処理",
+			"LectureId": "L0146",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0146.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+		}
+	]`,
+	writer2.Body.String())
+
+	// ------------------------------
+	// case3: name=松田　崇弘
+	// ------------------------------
+	// mockの設定
+	expectedRows3 := sqlmock.NewRows(cols).AddRow(
+		2023,
+		"後期",
+		"木",
+		"2限",
+		"松田 崇弘",
+		"無線ネットワーク（CS）",
+		"L0141",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/4/2023_A6_L0141.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%松%田%崇%弘%").WillReturnRows(expectedRows3)
+
+	// 検証用のcontext
+	writer3 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context3, engine3 := gin.CreateTestContext(writer3)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine3, gormDB)
+
+	// リクエストのシミュレート
+	context3.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=松田　崇弘", nil)
+	engine3.ServeHTTP(writer3, context3.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer3.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "木",
+			"Period": "2限",
+			"Teacher": "松田 崇弘",
+			"Name": "無線ネットワーク（CS）",
+			"LectureId": "L0141",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/4/2023_A6_L0141.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+		}
+	]`,
+	writer3.Body.String())
+}
+
+// test6
+func TestSyllabusTeacherRouteCharacterVariation(t *testing.T) {
+	// アルファベットの全角半角に関する頑健性を検証
+	// case1: 全半角 -> TestSyllabusTeacherRouteEnName
+	// case2: 全全角
+	// case3: case2からの絞り込み（検索が機能していることの検証）
+
+	db, gormDB, mock, cols := TeacherRouteTestSetup(t)
+	defer db.Close()
+	
+	// ------------------------------
+	// case1: 全半角, Already verified @ TestSyllabusTeacherRouteEnName.
+	// ------------------------------
+
+	// ------------------------------
+	// case2: 全全角, name=Ａｄａｍ
+	// ------------------------------
+	// mockの設定
+	expectedRows2 := sqlmock.NewRows(cols)
+	expectedRows2.AddRow(
+		2023,
+		"前期",
+		"月",
+		"2限",
+		"AdamLincCronin",
+		"Ecology（生態学各論）",
+		"I429",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_05_I429.html",
+		"専門教育科目",
+		"05",
+	)
+	expectedRows2.AddRow(
+		2023,
+		"後期",
+		"水",
+		"4限",
+		"VerlAdams",
+		"SeminarinSpatialDesignⅡ",
+		"L0761",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0761.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%Ａ%ｄ%ａ%ｍ%").WillReturnRows(expectedRows2)
+
+	// 検証用のcontext
+	writer2 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context2, engine2 := gin.CreateTestContext(writer2)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine2, gormDB)
+
+	// リクエストのシミュレート
+	context2.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=Ａｄａｍ", nil)
+	engine2.ServeHTTP(writer2, context2.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer2.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "前期",
+			"Day": "月",
+			"Period": "2限",
+			"Teacher": "AdamLincCronin",
+			"Name": "Ecology（生態学各論）",
+			"LectureId": "I429",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_05_I429.html",
+			"Type": "専門教育科目",
+			"Faculty": "05",
+			"DeletedAt": null
+		},
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "水",
+			"Period": "4限",
+			"Teacher": "VerlAdams",
+			"Name": "SeminarinSpatialDesignⅡ",
+			"LectureId": "L0761",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0761.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+		}
+	]`,
+	writer2.Body.String())
+
+	// ------------------------------
+	// case3: 全全角, name=ＶｅｒｌＡｄａｍｓ
+	// ------------------------------
+	// mockの設定
+	expectedRows3 := sqlmock.NewRows(cols)
+	expectedRows3.AddRow(
+		2023,
+		"後期",
+		"水",
+		"4限",
+		"VerlAdams",
+		"SeminarinSpatialDesignⅡ",
+		"L0761",
+		2,
+		"http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0761.html",
+		"専門教育科目",
+		"A6",
+	)
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE teacher LIKE \\?").WithArgs("%Ｖ%ｅ%ｒ%ｌ%Ａ%ｄ%ａ%ｍ%ｓ%").WillReturnRows(expectedRows3)
+
+	// 検証用のcontext
+	writer3 := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context3, engine3 := gin.CreateTestContext(writer3)
+
+	// routeの設定
+	SyllabusTeacherRoutes(engine3, gormDB)
+
+	// リクエストのシミュレート
+	context3.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/teacher?name=ＶｅｒｌＡｄａｍｓ", nil)
+	engine3.ServeHTTP(writer3, context3.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer3.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t,
+	`[
+		{
+			"Year": 2023,
+			"Season": "後期",
+			"Day": "水",
+			"Period": "4限",
+			"Teacher": "VerlAdams",
+			"Name": "SeminarinSpatialDesignⅡ",
+			"LectureId": "L0761",
+			"Credits": 2,
+			"URL": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0761.html",
+			"Type": "専門教育科目",
+			"Faculty": "A6",
+			"DeletedAt": null
+		}
+	]`,
+	writer3.Body.String())
+}
+
+

--- a/src/routes/syllabus_teacher_test.go
+++ b/src/routes/syllabus_teacher_test.go
@@ -25,7 +25,7 @@ import (
 // for1,2: test1~3
 // for2: test4
 // for3: test5
-// for4: test6
+// for4: test3, 6
 // 
 // test1: 異なる2日本人教員について正常な絞り込みかどうか検証
 // test2: 似た名前の2日本人教員について正常な絞り込みかどうか検証

--- a/src/routes/syllabus_teacher_test.go
+++ b/src/routes/syllabus_teacher_test.go
@@ -58,14 +58,14 @@ func TestSyllabusTeacherRoutes(t *testing.T) {
 			name: "存在しない教員",
 			testFunc: TestSyllabusTeacherRouteUnknownName,
 		},
-		// {
-		// 	name: "姓名間のスペースの有無への頑健性（日本人教員）",
-		// 	testFunc: ,
-		// },
-		// {
-		// 	name: "姓名間のスペースの有無への頑健性（外国人教員）",
-		// 	testFunc: ,
-		// },
+		{
+			name: "姓名間のスペースの有無への頑健性（日本人教員）",
+			testFunc: TestSyllabusTeacherRouteWhitespaceVariation,
+		},
+		{
+			name: "全角半角への頑健性（外国人教員）",
+			testFunc: TestSyllabusTeacherRouteCharacterVariation,
+		},
 	}
 
 	for _, tt := range tests{


### PR DESCRIPTION
## 概要
教員名でシラバスを検索するAPIを実装するPRです．from #3 .

- created: 3/20 00:00
- 追記1@議論: 3/20 00:10
- **テスト**の加筆: 3/21 4:15
- パラメータの種類を修正: 3/21 4:15

## 変更点
- 実装したrouteを設定
  - mod: `main.go`
- 実装したAPIのドキュメントを追加
  - mod: `docs/docs.go`, `docs/swagger.json`, `docs/swagger.yaml`
- controllerの実装
  - add: `src/controllers/syllabus_teacher.go`
  - パラメータの部分一致で検索する
  - **姓名の間のスペースをどう扱いますか？** -> **議論**
- routerの実装
  - add: `src/routes/syllabus_teacher.go`
  - クエリパラメータで教員名を指定する．
  - `syllabus/teacher?name={name}`
- testの設置
  - add: `sec/routes/syllabus_teacher_test.go`

## 影響範囲
- `main.go`
  - routeを設定したため，変更がある．
  - 他の機能への影響は無し．
- `docs/*`
  - 教員名でシラバスを検索するrouteについて，documentを追加した．
  - 他の機能へ影響は無し．

## テスト
テストで検証するのは
1. 指定した名前の教員が担当する授業が返されること
2. 指定した名前の教員以外が担当する授業が返されないこと
3. 姓名の間のスペースの有無を吸収できていること
4. アルファベットの全角半角に対応できていること

の4点とした．

実施するテスト内容と対応する検証要素は次の通り．
- 異なる日本人教員2人について，それぞれの名前を指定したとき，対応するシラバスのみが返ってくること(1, 2)
- 似た名前の日本人教員2人について，検索パラメータの変更によって絞り込みが行われること(1, 2)
- 異なる外国人教員2人について，それぞれの名前を指定したとき，対応するシラバスのみが返ってくること(1, 2, 4)
- 存在しない教員について，結果が空になること(2)
- 姓名間のスペースを``, ` `, `　`と変え，絞り込みが行えること(3)
- 全角で名前を入力したとき，正常に検索が行えること(4)

## 議論
### 教員名の性と名の間のスペースをどう扱いますか？
DB内に格納されている教員名は，確か次のような規則だったはず．
- 日本人: 半角スペース区切りで`性 名`
  - `山口 拓生`
- それ以外: スペース無し`FirstSecond`
  - `TakuoYamaguchi`

このとき，教員名として
1. 姓名間のスペースが無いもの e.g. `山口拓生`
2. 姓名間が全角スペースのもの e.g. `山口　拓生`
3. 英語表記の名前で，スペースを含むもの e.g. `Takuo Yamaguchi`

等が来たとき，どうするべきでしょうか．
ケース2, 3についてはどうにかなりそうなのですが，ケース1は姓名の区切りが分からず，困っています．

追記1:
石池で`山口拓生`のケースを試したところ，ヒットしなかったので，おそらく`WHERE teacher=%{name}%`のような検索をしているような気がします．この実装で十分な気もします．