### PR TITLE
fix: goコンテナをmysqlの初期化が完了してから起動するように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql  # MySQLデータの永続化
       - ./my.cnf:/config/my.cnf
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
   test:
     build:
       context: .
@@ -42,6 +47,7 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - mysql
+      mysql:
+        condition: service_healthy
 volumes:
   mysql_data:  # ボリュームの定義


### PR DESCRIPTION
fix #34 

goコンテナをmysqlの初期化が完了してから起動するように変更するPRです．

### 変更点
- `docker-compose.yml`のmysqlコンテナの設定に`healthcheck`属性を追加
コンテナがhealthyであるかどうかを判断するコマンドを設定しています

- `docker-compose.yml`のgoコンテナの設定で，`depends_on::mysql::service_healthy`属性を追加
mysqlコンテナがhealthyになるまで起動を待つようになるようです

### 参考
[公式ドキュメント](https://docs.docker.com/compose/startup-order/)