### PR TITLE
feature: 科目名からシラバスを検索するエンドポイントの作成

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -38,6 +38,44 @@ const docTemplate = `{
                 }
             }
         },
+        "/syllabus/course": {
+            "get": {
+                "description": "クエリパラメータnameと部分一致するシラバスを返します．",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "科目名でシラバスを検索します．",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "course name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SyllabusViewModel"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid course name exception",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/syllabus/faculty/{code}": {
             "get": {
                 "description": "パラメータ引数に与えた学部コードに一致するシラバスを返します．",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -27,6 +27,44 @@
                 }
             }
         },
+        "/syllabus/course": {
+            "get": {
+                "description": "クエリパラメータnameと部分一致するシラバスを返します．",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tags"
+                ],
+                "summary": "科目名でシラバスを検索します．",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "course name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.SyllabusViewModel"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid course name exception",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/syllabus/faculty/{code}": {
             "get": {
                 "description": "パラメータ引数に与えた学部コードに一致するシラバスを返します．",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -42,6 +42,31 @@ paths:
       summary: シラバス全データ取得
       tags:
       - tags
+  /syllabus/course:
+    get:
+      consumes:
+      - application/json
+      description: クエリパラメータnameと部分一致するシラバスを返します．
+      parameters:
+      - description: course name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.SyllabusViewModel'
+        "400":
+          description: invalid course name exception
+          schema:
+            type: string
+      summary: 科目名でシラバスを検索します．
+      tags:
+      - tags
   /syllabus/faculty/{code}:
     get:
       consumes:

--- a/main.go
+++ b/main.go
@@ -1,15 +1,16 @@
 package main
 
 import (
+	_ "InfoLinkAPI/docs"
+	"InfoLinkAPI/src/models"
+	"InfoLinkAPI/src/routes"
+
 	"github.com/gin-gonic/gin"
+	swaggerFiles "github.com/swaggo/files"
+	ginSwagger "github.com/swaggo/gin-swagger"
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
-	"InfoLinkAPI/src/models"
-	"InfoLinkAPI/src/routes"
-	_ "InfoLinkAPI/docs"
-	swaggerFiles "github.com/swaggo/files"
-    ginSwagger "github.com/swaggo/gin-swagger"
 )
 
 func main() {
@@ -37,6 +38,7 @@ func main() {
 	routes.SyllabusRandomRoutes(router, db)
 	routes.SyllabusFacultyRoutes(router, db)
 	routes.SyllabusTeacherRoutes(router, db)
+	routes.SyllabusCourseRoutes(router, db)
 	// ....
 	// ....
 

--- a/src/controllers/syllabus_course.go
+++ b/src/controllers/syllabus_course.go
@@ -33,6 +33,11 @@ func (sc *SyllabusController) GetSyllabusByCourseName(c *gin.Context) {
 	// ビューモデルに変換
 	syllabusViewModels := models.GetSyllabusViewModelBySyllabusBaseInfo(syllabusBaseInfos)
 
+	if len(syllabusViewModels) == 0 {
+		c.JSON(http.StatusOK, []models.SyllabusViewModel{})
+		return
+	}
+
 	// HTTPレスポンス
 	c.JSON(http.StatusOK, syllabusViewModels)
 }

--- a/src/controllers/syllabus_course.go
+++ b/src/controllers/syllabus_course.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"InfoLinkAPI/src/models"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetSyllabusByCourseName 指定した科目名のシラバスを取得し，HTTPレスポンスを行う。
+//
+// 部分一致で検索する。
+// APIドキュメント: https://www.notion.so/42e2fc5ed65a4ba2b6c3ea8bd4dcaad8?pvs=4
+func (sc *SyllabusController) GetSyllabusByCourseName(c *gin.Context) {
+	// シラバス配列
+	var syllabusBaseInfos []models.SyllabusBaseInfo
+	// クエリパラメータから科目名を取得
+	courseName := c.Query("name")
+	// クエリパラメータがない場合エラー
+	if courseName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid course name. See: https://www.notion.so/42e2fc5ed65a4ba2b6c3ea8bd4dcaad8?pvs=4"})
+		return
+	}
+
+	// 部分一致で検索
+	result := sc.DB.Where("name LIKE ?", "%"+courseName+"%").Find(&syllabusBaseInfos)
+	// エラーハンドリング
+	if result.Error != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": result.Error.Error()})
+		return
+	}
+
+	// ビューモデルに変換
+	syllabusViewModels := models.GetSyllabusViewModelBySyllabusBaseInfo(syllabusBaseInfos)
+
+	// HTTPレスポンス
+	c.JSON(http.StatusOK, syllabusViewModels)
+}

--- a/src/models/syllabus_view.go
+++ b/src/models/syllabus_view.go
@@ -17,18 +17,23 @@ type SyllabusViewModel struct {
 	Faculty    string `json:"faculty"`
 }
 
-func GetSyllabusViewModelBySyllabusBaseInfo(syllabusBaseInfo SyllabusBaseInfo) SyllabusViewModel {
-	return SyllabusViewModel{
-		Year:       syllabusBaseInfo.Year,
-		Season:     syllabusBaseInfo.Season,
-		Day:        syllabusBaseInfo.Day,
-		Period:     syllabusBaseInfo.Period,
-		Teacher:    syllabusBaseInfo.Teacher,
-		Name:       syllabusBaseInfo.Name,
-		LectureId:  syllabusBaseInfo.LectureId,
-		Credits:    syllabusBaseInfo.Credits,
-		URL:        syllabusBaseInfo.URL,
-		Type:       syllabusBaseInfo.Type,
-		Faculty:    syllabusBaseInfo.Faculty,
+func GetSyllabusViewModelBySyllabusBaseInfo(syllabusBaseInfo []SyllabusBaseInfo) []SyllabusViewModel {
+	var syllabusViewModels []SyllabusViewModel
+	for _, syllabus := range syllabusBaseInfo {
+		syllabusViewModel := SyllabusViewModel{
+			Year:       syllabus.Year,
+			Season:     syllabus.Season,
+			Day:        syllabus.Day,
+			Period:     syllabus.Period,
+			Teacher:    syllabus.Teacher,
+			Name:       syllabus.Name,
+			LectureId:  syllabus.LectureId,
+			Credits:    syllabus.Credits,
+			URL:        syllabus.URL,
+			Type:       syllabus.Type,
+			Faculty:    syllabus.Faculty,
+		}
+		syllabusViewModels = append(syllabusViewModels, syllabusViewModel)
 	}
+	return syllabusViewModels
 }

--- a/src/models/syllabus_view.go
+++ b/src/models/syllabus_view.go
@@ -16,3 +16,19 @@ type SyllabusViewModel struct {
 	Type       string `json:"type"`
 	Faculty    string `json:"faculty"`
 }
+
+func GetSyllabusViewModelBySyllabusBaseInfo(syllabusBaseInfo SyllabusBaseInfo) SyllabusViewModel {
+	return SyllabusViewModel{
+		Year:       syllabusBaseInfo.Year,
+		Season:     syllabusBaseInfo.Season,
+		Day:        syllabusBaseInfo.Day,
+		Period:     syllabusBaseInfo.Period,
+		Teacher:    syllabusBaseInfo.Teacher,
+		Name:       syllabusBaseInfo.Name,
+		LectureId:  syllabusBaseInfo.LectureId,
+		Credits:    syllabusBaseInfo.Credits,
+		URL:        syllabusBaseInfo.URL,
+		Type:       syllabusBaseInfo.Type,
+		Faculty:    syllabusBaseInfo.Faculty,
+	}
+}

--- a/src/routes/syllabus_course.go
+++ b/src/routes/syllabus_course.go
@@ -1,0 +1,25 @@
+package routes
+
+import (
+	"InfoLinkAPI/src/controllers"
+	_ "InfoLinkAPI/src/models"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// @Summary 科目名でシラバスを検索します．
+// @Description クエリパラメータnameと部分一致するシラバスを返します．
+// @Tags tags
+// @Accept  json
+// @Produce  json
+// @Param	name query string true "course name"
+// @Success 200 {object} models.SyllabusViewModel
+// @failure 400 {object} string "invalid course name exception"
+// @Router /syllabus/course [get]
+func SyllabusCourseRoutes(router *gin.Engine, db *gorm.DB) {
+	syllabusController := controllers.SyllabusController{DB: db}
+
+	// this router needs url params to search syllabus by faculty code.
+	router.GET("/syllabus/course", syllabusController.GetSyllabusByCourseName)
+}

--- a/src/routes/syllabus_course_test.go
+++ b/src/routes/syllabus_course_test.go
@@ -1,0 +1,245 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// union
+func TestSyllabusCourseRoutes(t *testing.T) {
+	// ------------------------------
+	// test1: クエリパラメータで科目名が指定され，該当レコードが存在する場合
+	// test2: クエリパラメータで科目名が指定され，該当レコードが存在しない場合
+	// test3: クエリパラメータが存在しない場合
+	// ------------------------------
+	type TestCase struct {
+		name string
+		testFunc func(t *testing.T)
+	}
+
+	tests := []TestCase{
+		{
+			name: "test1",
+			testFunc: TestSyllabusCourseRoutesValidNameResultHit,
+		},
+		{
+			name: "test2",
+			testFunc: TestSyllabusCourseRoutesValidNameResultUnHit,
+		},
+		{
+			name: "test3",
+			testFunc: TestSyllabusCourseRoutesNoQueryParam,
+		},
+	}
+
+	for _, tt := range tests{
+		t.Run(tt.name, func(t *testing.T){
+			tt.testFunc(t)
+		})
+	}
+}
+
+// test1
+// クエリパラメータで科目名が指定され，該当レコードが存在する場合
+func TestSyllabusCourseRoutesValidNameResultHit(t *testing.T) {
+	// mockDBの開設
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close() // 全部終わったらdbを閉じる
+	// DBのカラム名を定義しておく
+	cols := []string{"year", "season", "day", "period", "teacher", "name", "lecture_id", "credits", "url", "type", "faculty"}
+
+	// GORMからmockDBに接続する
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{
+		Conn: db,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a GORM database connection", err)
+	}
+
+	// Ginエンジンをtest用に設定
+	gin.SetMode(gin.TestMode)
+
+	// ------------------------------
+	// case1: name=データ構造とアルゴリズム演習（CS）
+	// ------------------------------
+	{
+		// mockの設定
+		expectedRows := sqlmock.NewRows(cols).AddRow(2023, "後期", "水", "2限", "岡本 正吾", "データ構造とアルゴリズム演習（CS）", "L0111", 2, "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0111.html", "専門教育科目", "A6")
+		mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE name LIKE \\?").WithArgs("%データ構造とアルゴリズム演習（CS）%").WillReturnRows(expectedRows)
+
+		// 検証用のcontextを設ける
+		writer := httptest.NewRecorder() // inspectable http.ResponseWriter
+		context, engine := gin.CreateTestContext(writer)
+
+		// routeの設定
+		SyllabusCourseRoutes(engine, gormDB)
+
+		// リクエストのシミュレート
+		context.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/course", nil)
+		// クエリパラメータを設定
+		context.Request.URL.RawQuery = "name=データ構造とアルゴリズム演習（CS）"
+		engine.ServeHTTP(writer, context.Request)
+
+		// レスポンスをアサート
+		assert.Equal(t, http.StatusOK, writer.Code)
+		// レスポンスのボディをアサート
+		assert.JSONEq(t,
+		`[{
+			"year": 2023,
+			"season": "後期",
+			"day": "水",
+			"period": "2限",
+			"teacher": "岡本 正吾",
+			"name": "データ構造とアルゴリズム演習（CS）",
+			"lectureId": "L0111",
+			"credits": 2,
+			"url": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0111.html",
+			"type": "専門教育科目",
+			"faculty": "A6"
+		}]`,
+		writer.Body.String())
+	}
+	// ------------------------------
+	// case2: name=基礎ゼミナール
+	// ------------------------------
+	{
+		// mockの設定
+		expectedRows := sqlmock.NewRows(cols).AddRow(2023, "前期", "月", "5限", "會田 雅樹", "基礎ゼミナール", "A0127", 2, "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_0D01_A0127.html", "基礎科目群", "0D01")
+		mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE name LIKE \\?").WithArgs("%基礎ゼミナール%").WillReturnRows(expectedRows)
+
+		// 検証用のcontextを設ける
+		writer := httptest.NewRecorder() // inspectable http.ResponseWriter
+		context, engine := gin.CreateTestContext(writer)
+
+		// routeの設定
+		SyllabusCourseRoutes(engine, gormDB)
+
+		// リクエストのシミュレート
+		context.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/course", nil)
+		// クエリパラメータを設定
+		context.Request.URL.RawQuery = "name=基礎ゼミナール"
+		engine.ServeHTTP(writer, context.Request)
+
+		// レスポンスをアサート
+		assert.Equal(t, http.StatusOK, writer.Code)
+		// レスポンスのボディをアサート
+		assert.JSONEq(t,
+		`[{
+			"year": 2023,
+			"season": "前期",
+			"day": "月",
+			"period": "5限",
+			"teacher": "會田 雅樹",
+			"name": "基礎ゼミナール",
+			"lectureId": "A0127",
+			"credits": 2,
+			"url": "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/0/1/2023_0D01_A0127.html",
+			"type": "基礎科目群",
+			"faculty": "0D01"
+		}]`,
+		writer.Body.String())
+	}
+}
+
+// test2
+// クエリパラメータで科目名が指定され，該当レコードが存在しない場合
+func TestSyllabusCourseRoutesValidNameResultUnHit(t *testing.T) {
+	// mockDBの開設
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close() // 全部終わったらdbを閉じる
+	// DBのカラム名を定義しておく
+	cols := []string{"year", "season", "day", "period", "teacher", "name", "lecture_id", "credits", "url", "type", "faculty"}
+
+	// GORMからmockDBに接続する
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{
+		Conn: db,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a GORM database connection", err)
+	}
+
+	// Ginエンジンをtest用に設定
+	gin.SetMode(gin.TestMode)
+
+	// mockの設定
+	expectedRows := sqlmock.NewRows(cols) // blank result
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE name LIKE \\?").WithArgs("%デタゴリ🦍%").WillReturnRows(expectedRows)
+
+	// 検証用のcontextを設ける
+	writer := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context, engine := gin.CreateTestContext(writer)
+
+	// routeの設定
+	SyllabusCourseRoutes(engine, gormDB)
+
+	// リクエストのシミュレート
+	context.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/course", nil)
+	// クエリパラメータを設定
+	context.Request.URL.RawQuery = "name=デタゴリ🦍"
+	engine.ServeHTTP(writer, context.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusOK, writer.Code)
+	// レスポンスのボディをアサート
+	assert.JSONEq(t, `[]`, writer.Body.String())
+}
+
+// test3
+// クエリパラメータが存在しない場合
+func TestSyllabusCourseRoutesNoQueryParam(t *testing.T) {
+	// mockDBの開設
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer db.Close() // 全部終わったらdbを閉じる
+	// DBのカラム名を定義しておく
+	cols := []string{"year", "season", "day", "period", "teacher", "name", "lecture_id", "credits", "url", "type", "faculty"}
+
+	// GORMからmockDBに接続する
+	gormDB, err := gorm.Open(mysql.New(mysql.Config{
+		Conn: db,
+		SkipInitializeWithVersion: true,
+	}), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("An error '%s' was not expected when opening a GORM database connection", err)
+	}
+
+	// Ginエンジンをtest用に設定
+	gin.SetMode(gin.TestMode)
+
+	// mockの設定
+	expectedRows := sqlmock.NewRows(cols).AddRow(2023, "後期", "水", "2限", "岡本 正吾", "データ構造とアルゴリズム演習（CS）", "L0111", 2, "http://www.kyouikujouhou.eas.tmu.ac.jp/syllabus/2023/A/3/2023_A6_L0111.html", "専門教育科目", "A6")
+	mock.ExpectQuery("^SELECT \\* FROM `syllabus_base_infos` WHERE name LIKE \\?").WithArgs("%データ構造とアルゴリズム演習（CS）%").WillReturnRows(expectedRows)
+
+	// 検証用のcontextを設ける
+	writer := httptest.NewRecorder() // inspectable http.ResponseWriter
+	context, engine := gin.CreateTestContext(writer)
+
+	// routeの設定
+	SyllabusCourseRoutes(engine, gormDB)
+
+	// リクエストのシミュレート
+	context.Request, _ = http.NewRequest(http.MethodGet, "/syllabus/course", nil)
+	engine.ServeHTTP(writer, context.Request)
+
+	// レスポンスをアサート
+	assert.Equal(t, http.StatusBadRequest, writer.Code)
+	// レスポンスのボディをアサート
+	assert.Equal(t, `{"error":"Invalid course name. See: https://www.notion.so/42e2fc5ed65a4ba2b6c3ea8bd4dcaad8?pvs=4"}`, writer.Body.String())
+}


### PR DESCRIPTION
close #2 

科目名からシラバスを部分一致で検索するAPIを作成しました．

## 変更点
- `SyllabusController`に`GetSyllabusByCourseName`メソッドを追加

ドメインロジック部分です．
クエリパラメータ`name`を読み取り，その文字列を使用して**部分一致検索**します．
部分一致検索の実装は，SQLで`WHERE name LIKE %検索文字列%`としました．
クエリの結果ををビューモデルに変換してHTTPレスポンスしています．

- `src/routes/syllabus_course.go`を追加

APIルート`/syllabus/course`を設定しています．
`router.GET()`を実行しているだけですが，swagger用のコメントを見よう見まねでやっているので確認お願いしたいです
あと，ルートを設定するそれぞれの関数の中でコントローラのインスタンスを新しく生成しているので，各ルートに対してそれぞれコントローラのインスタンスが存在している感じで若干リソースの無駄な気がします

- `src/models/syllabus_view.go`に`GetSyllabusViewModelBySyllabusBaseInfo`関数を追加

`SyllabusBaseInfo`モデルから`SyllabusViewModel`を作成する関数です．

- フォーマッタによる修正

vscodeのgo言語標準フォーマッタが`main.go`のimportを並べ替えてしまっています．邪魔だったら修正します

### APIドキュメント
[notion](https://www.notion.so/42e2fc5ed65a4ba2b6c3ea8bd4dcaad8?pvs=4)

### テスト
テストもtenkさんのを参考に見よう見まねで書いたので怪しいところあるかもしれません．

