### PR TITLE
CORS cross originを全て許可する設定に変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm/logger"
 	"InfoLinkAPI/src/models"
 	"InfoLinkAPI/src/routes"
+	"net/http"
 	_ "InfoLinkAPI/docs"
 	swaggerFiles "github.com/swaggo/files"
     ginSwagger "github.com/swaggo/gin-swagger"
@@ -28,6 +29,20 @@ func main() {
     db.AutoMigrate(&models.SyllabusBaseInfo{})
 
     router := gin.Default()
+
+	router.Use(func(c *gin.Context) {
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+		c.Writer.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS, GET, PUT")
+	
+		if c.Request.Method == "OPTIONS" {
+			c.AbortWithStatus(http.StatusNoContent)
+			return
+		}
+	
+		c.Next()
+	})
 
 	// Swaggerの設定
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))


### PR DESCRIPTION
### 変更箇所
main.goにCORS cross originを全て許可する設定を追加しました。

### 影響範囲
CORS cross originの設定がされていなかったため、外から叩くことが出来ませんでしたが、どこからでも受け付けるようになります。
一般に公開するAPIなので、この設定で良いかと思います。